### PR TITLE
fix: when data folder have data.mdb missing

### DIFF
--- a/lav/utils/datasets/basic_dataset.py
+++ b/lav/utils/datasets/basic_dataset.py
@@ -36,7 +36,14 @@ class BasicDataset(Dataset):
             # Toss a coin
             if np.random.random() > self.percentage_data:
                 continue
-
+            exist_file = False
+            for lmb_file in glob.glob('{}/**'.format(full_path)):
+                # print(lmb_file.split('/')[-1])
+                if lmb_file.split('/')[-1] == 'data.mdb':
+                    exist_file = True
+            if not exist_file:
+                print('data.mdb is not exist in folder', full_path)
+                continue
             txn = lmdb.open(
                 full_path,
                 max_readers=1, readonly=True,


### PR DESCRIPTION
continue the training step without a break

otherwise, there may be an error like here:
```python
File "/LAV/lav/utils/datasets/lidar_painted_dataset.py", line 27, in __getitem__
  lidar_painted = self.__class__.access('lidar_sem', lmdb_txn, index, 1).reshape(-1,len(self.seg_channels))
File "/LAV/lav/utils/datasets/basic_dataset.py", line 83, in <listcomp>
  return np.stack([np.frombuffer(lmdb_txn.get((f'{tag}_{t:05d}{suffix}').encode()), dtype) for t in range(index,index+T)])
TypeError: a bytes-like object is required, not 'NoneType'
```

and these issues related:
https://github.com/dotchen/LAV/issues/2#issuecomment-1148136434
https://github.com/dotchen/LAV/issues/9#issue-1194395147